### PR TITLE
Comparing only info without URL constructor check

### DIFF
--- a/packages/electron-updater/src/DownloadedUpdateHelper.ts
+++ b/packages/electron-updater/src/DownloadedUpdateHelper.ts
@@ -28,7 +28,7 @@ export class DownloadedUpdateHelper {
     if (this.versionInfo != null && this.file === updateFile) {
       // update has already been downloaded from this running instance
       // check here only existence, not checksum
-      return isEqual(this.versionInfo, versionInfo) && isEqual(this.fileInfo, fileInfo) && (await pathExists(updateFile))
+      return isEqual(this.versionInfo, versionInfo) && isEqual(this.fileInfo.info, fileInfo.info) && (await pathExists(updateFile))
     }
 
     // update has already been downloaded from some previous app launch


### PR DESCRIPTION
`fileInfo` contains info of file and URL constructor. Somehow it returns false while doing lodash comparison of whole fileinfo object because of URL constructor. So comparing only file info as of now.